### PR TITLE
Gedcom#direct! prunes tree to only direct ancestors

### DIFF
--- a/lib/active_gedcom/gedcom.rb
+++ b/lib/active_gedcom/gedcom.rb
@@ -68,6 +68,15 @@ module ActiveGedcom
       end
     end
 
+    def direct!
+      direct_person_ids = []
+      recurse_family(people.values.first) do |person, level|
+        direct_person_ids << person.id
+      end
+
+      people.delete_if { |id, person| !direct_person_ids.include?(id) }
+    end
+
     def to_text
       lines = []
       recurse_family(people.values.first) do |person, level|


### PR DESCRIPTION
I wanted to see the graph without all the siblings and cousins.  Added `Gedcom#direct!` to achieve this, but would be interested to make `gedcom.direct.to_dot` work instead of `gedcom.direct! ; gedcom.to_dot` if there were a way to initialize from data.
